### PR TITLE
Checkout the branch before building projects

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -3,14 +3,4 @@ set -e
 
 [ -n "${PULL}" ] && git pull --rebase
 
-git fetch
-if [ -z "${BRANCH}" ];
- then
- echo "Using default branch";
-else
- git fetch
- echo "Checking out branch '${BRANCH}' for $(pwd)";
- git checkout ${BRANCH};
-fi
-
 echo "cloned into $(REPO_DIR)"

--- a/for-each-repo.sh
+++ b/for-each-repo.sh
@@ -28,6 +28,14 @@ do
   else
     cd ${REPO}
   fi
+  if [ -z "${BRANCH}" ];
+   then
+   echo "Using default branch";
+  else
+   git fetch
+   echo "Checking out branch '${BRANCH}' for $(pwd)";
+   git checkout $BRANCH || ${IGNORE_BRANCH_CHECKOUT_FAILURE:true}
+  fi
   ${SCRIPT:-echo I\'m in ${REPO}}
   echo "*************** EXECUTE ON ${REPO} :: END   ***************"
   popd > /dev/null


### PR DESCRIPTION
if the branch does not exist the error will be ignored unless the variable IGNORE_BRANCH_CHECKOUT_FAILURE is set to false