### PR TITLE
put back to 7.1 train

### DIFF
--- a/repos-activiti-cloud-modeling.txt
+++ b/repos-activiti-cloud-modeling.txt
@@ -1,3 +1,3 @@
-activiti-cloud-modeling-build
-activiti-cloud-org-service
-activiti-cloud-modeling-dependencies
+activiti-cloud-modeling-build 7.1.4
+activiti-cloud-org-service 7.1.25
+activiti-cloud-modeling-dependencies 7.1.29

--- a/repos-activiti-cloud.txt
+++ b/repos-activiti-cloud.txt
@@ -1,11 +1,11 @@
-activiti-cloud-build
-activiti-cloud-api
-activiti-cloud-service-common
-activiti-cloud-runtime-bundle-service
-activiti-cloud-query-service
-activiti-cloud-audit-service
-activiti-cloud-connectors
-activiti-cloud-app-service
-activiti-cloud-acceptance-tests
-activiti-cloud-notifications-service-graphql
-activiti-cloud-dependencies
+activiti-cloud-build 7.1.6
+activiti-cloud-api 7.1.12
+activiti-cloud-service-common 7.1.17
+activiti-cloud-runtime-bundle-service 7.1.18
+activiti-cloud-query-service 7.1.18
+activiti-cloud-audit-service 7.1.15
+activiti-cloud-connectors 7.1.16
+activiti-cloud-app-service 7.1.15
+activiti-cloud-acceptance-tests 7.1.23
+activiti-cloud-notifications-service-graphql 7.1.16
+activiti-cloud-dependencies 7.1.28

--- a/repos-activiti.txt
+++ b/repos-activiti.txt
@@ -1,5 +1,5 @@
-activiti-build
-activiti-api
-activiti-core-common
-activiti
-activiti-dependencies
+activiti-build 7.1.7
+activiti-api 7.1.12
+activiti-core-common 7.1.8
+activiti 7.19
+activiti-dependencies 7.1.7


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/2609

Took the versions by looking at the latest tags from activiti-dependencies, activiti-cloud-dependencies and activiti-cloud-modeling-dependencies and getting versions from their pom files