### PR TITLE
Fetch version change order

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ will build all the repositories listed in the index files:
 
 To get the set of versions to be released:
 
-    fetch-versions.sh (fetch latest version for all sets)
-    fetch-versions.sh activiti-dependencies (fetch latest versions for the provided set)
-    fetch-versions.sh activiti-dependencies 7.1.18 (fetch set of versions for the provided set in the provided version set)
+    ./fetch-versions.sh (fetch latest version for all sets)
+    ./fetch-versions.sh activiti-dependencies (fetch latest versions for the provided set)
+    ./fetch-versions.sh activiti-dependencies 7.1.18 (fetch set of versions for the provided set in the provided version set)
     
 To clone all:
 

--- a/fetch-versions.sh
+++ b/fetch-versions.sh
@@ -31,9 +31,7 @@ do
     ;;
     esac
 
-    # name and version of the dependency aggregator
-    echo -n "$i " >> $file
-
+    name_dependency_aggregator=$i
     git fetch --tags
 
     if [ ! -z "$2" ]; then
@@ -50,7 +48,7 @@ do
 
         if [ "$exist" -eq 1 ]; then
             git checkout -q tags/v$2 
-            echo $2 >> $file 
+            version_dependency_aggregator=$2 
         else
             echo "The provided version does not exist"
             cd ../..
@@ -69,7 +67,7 @@ do
         fi  
 
         git checkout -q tags/$aggregator_tag
-        echo $aggregator_tag | cut -d'v' -f 2 >> $file
+        version_dependency_aggregator=$(echo $aggregator_tag | cut -d'v' -f 2)
     fi
 
     # name and version of the projects in this aggregator
@@ -86,6 +84,10 @@ do
             exit 1
         fi
     done
+
+    # name and version of the dependency aggregator
+    echo -n "$name_dependency_aggregator " >> $file
+    echo $version_dependency_aggregator >> $file 
 
     echo "--------------------------------------------------------------------"
     cat $file


### PR DESCRIPTION
For the release process to work as expected, the text files generated by the `fetch-versions.sh` script should have the name and version of the aggregator project at the end (given the fact that aggregator projects depend on the rest of the projects in order to be built, they should be built at the end)
The previous version of the script was providing the aggregator name and version at the beginning of the file.