### PR TITLE
Include activiti-modeling-app tag version to scripts

### DIFF
--- a/fetch-versions.sh
+++ b/fetch-versions.sh
@@ -85,6 +85,11 @@ do
         fi
     done
 
+    if [ $name_dependency_aggregator == "activiti-cloud-modeling-dependencies" ]; then
+        echo -n "activiti-modeling-app " >> $file
+        echo $(curl -s https://api.github.com/repos/Activiti/activiti-modeling-app/tags | grep name | cut -d'v' -f 2 | cut -d'"' -f 1 |  head -n1) >> $file
+    fi
+
     # name and version of the dependency aggregator
     echo -n "$name_dependency_aggregator " >> $file
     echo $version_dependency_aggregator >> $file 

--- a/fetch-versions.sh
+++ b/fetch-versions.sh
@@ -85,6 +85,7 @@ do
         fi
     done
 
+    # addition of modeling front end project
     if [ $name_dependency_aggregator == "activiti-cloud-modeling-dependencies" ]; then
         echo -n "activiti-modeling-app " >> $file
         echo $(curl -s https://api.github.com/repos/Activiti/activiti-modeling-app/tags | grep name | cut -d'v' -f 2 | cut -d'"' -f 1 |  head -n1) >> $file


### PR DESCRIPTION
Addressing this issue: https://github.com/Activiti/Activiti/issues/2726

Now, the output of the _fetch-scripts.sh_ script looks like:
```
--------------------------------------------------------------------
activiti-build 7.1.14
activiti-api 7.1.26
activiti-core-common 7.1.26
activiti 7.1.36
activiti-dependencies 7.1.28
--------------------------------------------------------------------
activiti-cloud-build 7.1.7
activiti-cloud-api 7.1.24
activiti-cloud-service-common 7.1.35
activiti-cloud-runtime-bundle-service 7.1.55
activiti-cloud-query-service 7.1.46
activiti-cloud-audit-service 7.1.40
activiti-cloud-connectors 7.1.34
activiti-cloud-app-service 7.1.32
activiti-cloud-acceptance-tests 7.1.47
activiti-cloud-notifications-service-graphql 7.1.50
activiti-cloud-dependencies 7.1.82
--------------------------------------------------------------------
activiti-cloud-modeling-build 7.1.4
activiti-cloud-org-service 7.1.74
activiti-modeling-app 0.0.94
activiti-cloud-modeling-dependencies 7.1.83
```
**activiti-modeling-app 0.0.94** can be noticed as part of the modeling-dependencies bundle

These changes add the **latest** tagged version available.