### PR TITLE
fix: using the VERSION to retrieve the tag to use

### DIFF
--- a/create-tag.sh
+++ b/create-tag.sh
@@ -10,10 +10,10 @@ then
   export SHOULD_INCREMENT_VERSION
 fi
 
-./fetch-versions.sh
-
 VERSION_TO_RELEASE=$(<VERSION)
 echo "Version to release ${VERSION_TO_RELEASE}"
+
+tag_pattern="${VERSION_TO_RELEASE%-mock*}-alpha*" ./fetch-versions.sh
 
 git add repos-*.txt
 git commit -m "Update versions - Activiti Cloud Dependencies"


### PR DESCRIPTION
The `${VERSION_TO_RELEASE%%-mock*}-alpha*` pattern ensures that
the tag will be retrieved using the version coming from the
release stream selected in `VERSION_TO_RELEASE`.

E.g.: `VERSION_TO_RELEASE=7.3.0` will produce a research of the
latest tag following the pattern `7.3.0-alpha*`

The variable also support mock release.

E.g.: `VERSION_TO_RELEASE=7.1.0-M17.6-mock` will produce a research of the
latest tag following the pattern `7.1.0-M17.6-alpha*` stripping
out the last `-mock` statement