### PR TITLE
Update release scripts to release from existing RC tag

### DIFF
--- a/.github/workflows/prepare-next-release.yml
+++ b/.github/workflows/prepare-next-release.yml
@@ -105,7 +105,7 @@ jobs:
         working-directory: ${{ env.REPO_DIR }}
         run: git push origin "$BRANCH"
 
-  create-maintenance-branch:
+  maven-create-maintenance-branch:
     if: endsWith(needs.load-release-info.outputs.version, '.0') || contains(needs.load-release-info.outputs.version, '.0-mock')
     runs-on: ubuntu-latest
     needs: [ load-release-info ]

--- a/.github/workflows/prepare-next-release.yml
+++ b/.github/workflows/prepare-next-release.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           add-options: -u
-          commit-message: Update to version ${{ env.NEXT_VERSION}}
+          commit-message: Update to version ${{ env.NEXT_VERSION}} [skip ci]
           repository-directory: ${{ env.REPO_DIR }}
 
       - name: Push changes to branch ${{ env.BRANCH }}
@@ -97,7 +97,7 @@ jobs:
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           add-options: -u
-          commit-message: Update to version ${{ env.NEXT_VERSION}}
+          commit-message: Update to version ${{ env.NEXT_VERSION}} [skip ci]
           repository-directory: ${{ env.REPO_DIR }}
 
       - name: Push changes to branch ${{ env.BRANCH }}
@@ -215,7 +215,7 @@ jobs:
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           add-options: -u
-          commit-message: Update to version ${{ steps.resolve-maintenance-version.outputs.version }}
+          commit-message: Update to version ${{ steps.resolve-maintenance-version.outputs.version }} [skip ci]
           repository-directory: ${{ env.REPO_DIR }}
 
       - name: Push changes to branch ${{ steps.calculate-maintenance-branch-name.outputs.branch }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,15 +39,6 @@ jobs:
         with:
           tag-pattern: ${{ env.TAG_PATTERN }}
 
-      - name: create-staging-repository
-        id: staging
-        uses: Alfresco/alfresco-build-tools/.github/actions/nexus-create-staging@v1.23.0
-        with:
-          staging-description: Activiti staging ${{ steps.load-descriptor.outputs.version }}
-          nexus-profile-id: ${{ secrets.NEXUS_ACTIVITI7_PROFILE_ID }}
-          nexus-username: ${{ secrets.NEXUS_USERNAME }}
-          nexus-password: ${{ secrets.NEXUS_PASSWORD }}
-
       - name: Checkout full chart
         uses: actions/checkout@v3
         with:
@@ -73,16 +64,11 @@ jobs:
 
       - name: Add release info
         env:
-          STAGING_REPOSITORY_ID: ${{ steps.staging.outputs.staging-repository }}
           COMMON_CHART_TAG: ${{ steps.chart-tags.outputs.common-chart-tag }}
           FULL_CHART_TAG: ${{ steps.chart-tags.outputs.full-chart-tag }}
-          STAGING_REPOSITORY_FILE: maven-config/staging-repository.txt
         run: |
-          echo "$STAGING_REPOSITORY_ID" > "$STAGING_REPOSITORY_FILE"
-
           yq -i e '.release.baseTag.commonChart = env(COMMON_CHART_TAG)' release.yaml
           yq -i e '.release.baseTag.fullChart = env(FULL_CHART_TAG)' release.yaml
-          yq -i e '.release.stagingRepository = env(STAGING_REPOSITORY_ID)' release.yaml
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.23.0
         with:

--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -223,7 +223,7 @@ jobs:
           repo: Activiti/Activiti
           base-ref: ${{  needs.load-release-info.outputs.activiti-tag }}
           release-version: ${{ needs.load-release-info.outputs.version }}
-          staging-repository:  ${{ steps.staging.outputs.staging-repository }}
+          staging-repository: ${{ steps.staging.outputs.staging-repository }}
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           gpg-passphrase: "${{ secrets.GPG_PASSPHRASE }}"

--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -203,7 +203,18 @@ jobs:
   release-activiti:
     runs-on: ubuntu-latest
     needs: [load-release-info]
+    outputs:
+      staging-repository: ${{ steps.staging.outputs.staging-repository }}
     steps:
+      - name: create-staging-repository
+        id: staging
+        uses: Alfresco/alfresco-build-tools/.github/actions/nexus-create-staging@v1.23.0
+        with:
+          staging-description: Activiti staging ${{ needs.load-release-info.outputs.version }}
+          nexus-profile-id: ${{ secrets.NEXUS_ACTIVITI7_PROFILE_ID }}
+          nexus-username: ${{ secrets.NEXUS_USERNAME }}
+          nexus-password: ${{ secrets.NEXUS_PASSWORD }}
+
       - name: Checkout activiti-scripts
         uses: actions/checkout@v3
 
@@ -212,7 +223,7 @@ jobs:
           repo: Activiti/Activiti
           base-ref: ${{  needs.load-release-info.outputs.activiti-tag }}
           release-version: ${{ needs.load-release-info.outputs.version }}
-          staging-repository: ${{ needs.load-release-info.outputs.staging-repository }}
+          staging-repository:  ${{ steps.staging.outputs.staging-repository }}
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           gpg-passphrase: "${{ secrets.GPG_PASSPHRASE }}"
@@ -223,7 +234,9 @@ jobs:
 
   release-activiti-cloud:
     runs-on: ubuntu-latest
-    needs: [load-release-info, release-activiti]
+    needs:
+      - load-release-info
+      - release-activiti
     steps:
       - name: Checkout activiti-scripts
         uses: actions/checkout@v3
@@ -234,7 +247,7 @@ jobs:
           base-ref: ${{  needs.load-release-info.outputs.activiti-cloud-tag }}
           extra-replacements: activiti.version=${{  needs.load-release-info.outputs.activiti-tag }}
           release-version: ${{ needs.load-release-info.outputs.version }}
-          staging-repository: ${{ needs.load-release-info.outputs.staging-repository }}
+          staging-repository: ${{ needs.release-activiti.outputs.staging-repository }}
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           gpg-passphrase: "${{ secrets.GPG_PASSPHRASE }}"
@@ -245,7 +258,10 @@ jobs:
 
   release-activiti-cloud-application:
     runs-on: ubuntu-latest
-    needs: [load-release-info, release-activiti-cloud]
+    needs:
+      - load-release-info
+      - release-activiti
+      - release-activiti-cloud
     steps:
       - name: Checkout activiti-scripts
         uses: actions/checkout@v3
@@ -258,7 +274,7 @@ jobs:
           base-ref: ${{  needs.load-release-info.outputs.activiti-cloud-application-tag }}
           extra-replacements: activiti-cloud.version=${{  env.ACT_CLOUD_VERSION }},version=${{  env.ACT_CLOUD_VERSION }}
           release-version: ${{ needs.load-release-info.outputs.version }}
-          staging-repository: ${{ needs.load-release-info.outputs.staging-repository }}
+          staging-repository: ${{ needs.release-activiti.outputs.staging-repository }}
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           gpg-passphrase: "${{ secrets.GPG_PASSPHRASE }}"
@@ -411,12 +427,13 @@ jobs:
 
   create-scripts-tag:
     runs-on: ubuntu-latest
-    needs: [ load-release-info, release-activiti-cloud-application, run-sanity-checks ]
+    needs:
+      - load-release-info
+      - release-activiti
+      - release-activiti-cloud-application
+      - run-sanity-checks
     env:
       RELEASE_VERSION: ${{ needs.load-release-info.outputs.version }}
-      STAGING_REPOSITORY_FILE: maven-config/staging-repository.txt
-      GIT_USERNAME: ${{ secrets.BOT_GITHUB_USERNAME }}
-
     steps:
       - name: Checkout activiti-scripts
         uses: actions/checkout@v3
@@ -428,10 +445,22 @@ jobs:
         with:
           tag: ${{ env.RELEASE_VERSION }}
 
+      - name: Update staging repository
+        env:
+          STAGING_REPOSITORY_FILE: maven-config/staging-repository.txt
+          STAGING_REPOSITORY_ID: ${{ needs.release-activiti.outputs.staging-repository }}
+        run: |
+          echo "$STAGING_REPOSITORY_ID" > "$STAGING_REPOSITORY_FILE"
+          yq -i e '.release.stagingRepository = env(STAGING_REPOSITORY_ID)' release.yaml
+
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.23.0
+        with:
+          username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          add-options: maven-config/staging-repository.txt release.yaml
+          commit-message: Add staging repository for ${{env.RELEASE_VERSION}}
+
       - name: Create tag
         if: steps.check-tag.outputs.exists == 'false'
         run: |
-          git config --global user.name $GIT_USERNAME
-          git config --global user.email ${GIT_USERNAME}@users.noreply.github.com
           git tag "$RELEASE_VERSION" -m "Release version $RELEASE_VERSION"
           git push origin "$RELEASE_VERSION"


### PR DESCRIPTION
It's possible now to create the release using the information available on the latest `rc` tag for activiti-scripts:
The latest `rc` has already the list of the base tags that should be used for releasing. For instance, check release.yaml for [7.7.0-rc.64](https://github.com/Activiti/activiti-scripts/blob/7.7.0-rc.64/release.yaml).
It's possible than, to skip the initial step of retrieving that tags to be used that was handled by `prepare-release.yaml`.

The new procedure to release is going to be:
- create a branch named `releases/main/<RELEASE_VERSION>` out of the latest `rc`
- update the attributes `version` and `nextVersion` of release.yaml 
- commit the changes
- push the new branch `releases/main/<RELEASE_VERSION>` that will trigger the release

The following adaptions was made the the workflow:
- the creation of Nexus stating repository was moved to the workflow running the release
- the CI will be skipped in the released projects when updating the project version to the next version
