### PR TITLE
Improvement in cleaning mock releases

### DIFF
--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -7,45 +7,43 @@ inputs:
   repo:
     description: 'Path to repo'
     required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repo }}
+        token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-jobs:
-  delete_version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ inputs.repo }}
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
-
-      - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
-        id: check-tag
-        with:
-          tag: ${{ inputs.version }}
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
+      id: check-tag
+      with:
+        tag: ${{ inputs.version }}
 
 
-      - name: Delete release if the provided version ends with "-mock"
-        id: delete_version
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          REPO: ${{ inputes.repo }}
-        run: |
-          if [[ "${VERSION}" == *-mock ]]; then
-            echo "Removing release from: ${REPO}"
-            gh release delete -R ${REPO} -y ${VERSION} || true
-          else
-            echo "version does not end with '-mock'."
-            echo "Error: The provided version does not end with '-mock.'"
-            exit 1
-          fi
+    - name: Delete release if the provided version ends with "-mock"
+      id: delete_version
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        VERSION: ${{ inputs.version }}
+        REPO: ${{ inputes.repo }}
+      run: |
+        if [[ "${VERSION}" == *-mock ]]; then
+          echo "Removing release from: ${REPO}"
+          gh release delete -R ${REPO} -y ${VERSION} || true
+        else
+          echo "version does not end with '-mock'."
+          echo "Error: The provided version does not end with '-mock.'"
+          exit 1
+        fi
 
-      - name: Delete tag if it exist
-        if: steps.check-tag.outputs.exists == 'true'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          echo "Removing tag from: ${REPO}"
-          git push origin --delete ${VERSION} || true
+    - name: Delete tag if it exist
+      if: steps.check-tag.outputs.exists == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        echo "Removing tag from: ${REPO}"
+        git push origin --delete ${VERSION} || true

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         repository: ${{ inputs.repo }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.gh-token }}
 
     - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
       id: check-tag
@@ -28,7 +28,7 @@ runs:
       id: delete_version
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.gh-token }}
         VERSION: ${{ inputs.version }}
         REPO: ${{ inputs.repo }}
       run: |
@@ -45,7 +45,7 @@ runs:
       if: steps.check-tag.outputs.exists == 'true'
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.gh-token }}
         VERSION: ${{ inputs.version }}
       run: |
         echo "Removing tag from: ${REPO}"

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -23,7 +23,6 @@ runs:
       with:
         tag: ${{ inputs.version }}
 
-
     - name: Delete release if the provided version ends with "-mock"
       id: delete_version
       shell: bash

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -34,7 +34,6 @@ runs:
           echo "Removing '${VERSION}' tag from: ${REPO}"
           git push origin --delete ${VERSION} || true
         else
-          echo "version does not end with '-mock'."
           echo "Error: The provided version does not end with '-mock.'"
           exit 1
         fi

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -45,7 +45,7 @@ runs:
       if: steps.check-tag.outputs.exists == 'true'
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         VERSION: ${{ inputs.version }}
       run: |
         echo "Removing tag from: ${REPO}"

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -23,15 +23,21 @@ runs:
       with:
         tag: ${{ inputs.version }}
 
-    - name: Delete tag if it exist
+    - name: Delete tag if it exist and ends with "-mock"
       if: steps.check-tag.outputs.exists == 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.gh-token }}
         VERSION: ${{ inputs.version }}
       run: |
-        echo "Removing '${VERSION}' tag from: ${REPO}"
-        git push origin --delete ${VERSION}
+        if [[ "${VERSION}" == *-mock ]]; then
+          echo "Removing '${VERSION}' tag from: ${REPO}"
+          git push origin --delete ${VERSION}
+        else
+          echo "version does not end with '-mock'."
+          echo "Error: The provided version does not end with '-mock.'"
+          exit 1
+        fi
 
     - name: Delete release if the provided version ends with "-mock"
       id: delete_version

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -13,12 +13,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         repository: ${{ inputs.repo }}
         token: ${{ inputs.gh-token }}
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@34b2301fc6245fa98ed73a82e04d4f9ab4eb5a3f #v3.6.0
       id: check-tag
       with:
         tag: ${{ inputs.version }}
@@ -32,8 +32,8 @@ runs:
         REPO: ${{ inputs.repo }}
       run: |
         if [[ "${VERSION}" == *-mock ]]; then
-          echo "Removing release from: ${REPO}"
-          gh release delete -R ${REPO} -y ${VERSION} || true
+          echo "Removing '${VERSION}' release from: ${REPO}"
+          gh release delete -R ${REPO} -y ${VERSION}
         else
           echo "version does not end with '-mock'."
           echo "Error: The provided version does not end with '-mock.'"
@@ -47,5 +47,5 @@ runs:
         GITHUB_TOKEN: ${{ inputs.gh-token }}
         VERSION: ${{ inputs.version }}
       run: |
-        echo "Removing tag from: ${REPO}"
-        git push origin --delete ${VERSION} || true
+        echo "Removing '${VERSION}' tag from: ${REPO}"
+        git push origin --delete ${VERSION}

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -51,7 +51,6 @@ runs:
           echo "Removing '${VERSION}' release from: ${REPO}"
           gh release delete -R ${REPO} -y ${VERSION}
         else
-          echo "version does not end with '-mock'."
           echo "Error: The provided version does not end with '-mock.'"
           exit 1
         fi

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -1,0 +1,51 @@
+name: Mock release cleanup
+description: Removal of release and tag
+inputs:
+  version:
+    description: 'Mock release version to be removed from tags and releases'
+    required: true
+  repo:
+    description: 'Path to repo'
+    required: true
+
+jobs:
+  delete_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repo }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
+        id: check-tag
+        with:
+          tag: ${{ inputs.version }}
+
+
+      - name: Delete release if the provided version ends with "-mock"
+        id: delete_version
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ inputes.repo }}
+        run: |
+          if [[ "${VERSION}" == *-mock ]]; then
+            echo "Removing release from: ${REPO}"
+            gh release delete -R ${REPO} -y ${VERSION} || true
+          else
+            echo "version does not end with '-mock'."
+            echo "Error: The provided version does not end with '-mock.'"
+            exit 1
+          fi
+
+      - name: Delete tag if it exist
+        if: steps.check-tag.outputs.exists == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          echo "Removing tag from: ${REPO}"
+          git push origin --delete ${VERSION} || true

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         if [[ "${VERSION}" == *-mock ]]; then
           echo "Removing '${VERSION}' tag from: ${REPO}"
-          git push origin --delete ${VERSION}
+          git push origin --delete ${VERSION} || true
         else
           echo "version does not end with '-mock'."
           echo "Error: The provided version does not end with '-mock.'"

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -7,13 +7,16 @@ inputs:
   repo:
     description: 'Path to repo'
     required: true
+  gh-token:
+    description: 'gh token'
+    required: true
 runs:
   using: composite
   steps:
     - uses: actions/checkout@v3
       with:
         repository: ${{ inputs.repo }}
-        token: ${{ secrets.BOT_GITHUB_TOKEN }}
+        token: ${{ inputs.token }}
 
     - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
       id: check-tag
@@ -25,9 +28,9 @@ runs:
       id: delete_version
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         VERSION: ${{ inputs.version }}
-        REPO: ${{ inputes.repo }}
+        REPO: ${{ inputs.repo }}
       run: |
         if [[ "${VERSION}" == *-mock ]]; then
           echo "Removing release from: ${REPO}"

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -23,6 +23,16 @@ runs:
       with:
         tag: ${{ inputs.version }}
 
+    - name: Delete tag if it exist
+      if: steps.check-tag.outputs.exists == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.gh-token }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        echo "Removing '${VERSION}' tag from: ${REPO}"
+        git push origin --delete ${VERSION}
+
     - name: Delete release if the provided version ends with "-mock"
       id: delete_version
       shell: bash
@@ -39,13 +49,3 @@ runs:
           echo "Error: The provided version does not end with '-mock.'"
           exit 1
         fi
-
-    - name: Delete tag if it exist
-      if: steps.check-tag.outputs.exists == 'true'
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.gh-token }}
-        VERSION: ${{ inputs.version }}
-      run: |
-        echo "Removing '${VERSION}' tag from: ${REPO}"
-        git push origin --delete ${VERSION}

--- a/.github/actions/remove-mock-release-and-tag/action.yml
+++ b/.github/actions/remove-mock-release-and-tag/action.yml
@@ -1,14 +1,14 @@
 name: Mock release cleanup
-description: Removal of release and tag
+description: Remove mock release and tag on a repository
 inputs:
   version:
-    description: 'Mock release version to be removed from tags and releases'
+    description: Mock release version to be removed from tags and releases (should end with -mock)
     required: true
   repo:
-    description: 'Path to repo'
+    description: Path the repository
     required: true
   gh-token:
-    description: 'gh token'
+    description: 'GitHub Token'
     required: true
 runs:
   using: composite

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,20 +20,35 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
-            echo "Removing releases and tags from: Activiti/activiti-cloud-full-chart"
-            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION} || true
+            echo "Removing release from: Activiti/activiti-cloud-full-chart"
+            gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
+            echo "Removing tag from: Activiti/activiti-cloud-full-chart"
+            gh repo clone Activiti/activiti-cloud-full-chart --depth 1
+            git push origin --delete ${VERSION} || true
 
-            echo "Removing releases and tags from: Activiti/activiti-scripts"
-            gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION} || true
+            echo "Removing release from: Activiti/activiti-scripts"
+            gh release delete -R Activiti/activiti-scripts -y ${VERSION} || true
+            echo "Removing tag from: Activiti/activiti-scripts"
+            gh repo clone Activiti/activiti-scripts --depth 1
+            git push origin --delete ${VERSION} || true
 
-            echo "Removing releases and tags from: Activiti/activiti-cloud"
-            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} || true
+            echo "Removing release from: Activiti/activiti-cloud"
+            gh release delete -R Activiti/activiti-cloud -y ${VERSION} || true
+            echo "Removing tag from: Activiti/activiti-cloud"
+            gh repo clone Activiti/activiti-cloud --depth 1
+            git push origin --delete ${VERSION} || true
 
-            echo "Removing releases and tags from: Activiti/activiti-cloud-common-chart"
-            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} || true
+            echo "Removing release from: Activiti/activiti-cloud-common-chart"
+            gh release delete -R Activiti/activiti-cloud-common-chart -y ${VERSION} || true
+            echo "Removing tag from: Activiti/activiti-cloud-common-chart"
+            gh repo clone Activiti/activiti-cloud-common-chart --depth 1
+            git push origin --delete ${VERSION} || true
 
-            echo "Removing releases and tags from: Activiti/activiti"
-            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} || true
+            echo "Removing release from: Activiti/activiti"
+            gh release delete -R Activiti/Activiti -y ${VERSION} || true
+            echo "Removing tag from: Activiti/activiti"
+            gh repo clone Activiti/activiti --depth 1
+            git push origin --delete ${VERSION} || true
 
           else
             echo "version does not end with '-mock'."

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
-            #gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
+            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
             echo "Activiti/activiti-cloud-full-chart cleaned"
             gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION}
             echo "Activiti/activiti-scripts cleaned"

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -17,3 +17,4 @@ jobs:
           version: ${{ inputs.version }}
           repo: Activiti/activiti-cloud-full-chart
           gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+      - uses: actions/checkout@v3

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -11,48 +11,29 @@ jobs:
   delete_version:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete version if the provided version ends with "-mock"
+      - uses: actions/checkout@v3
+        with:
+          repository: Activiti/activiti-cloud-full-chart
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
+        id: check-tag
+        with:
+          tag: ${{ inputs.version }}
+
+
+      - name: Delete release if the provided version ends with "-mock"
         id: delete_version
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          REPO: ${{ inputs.repository }}
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
-            git config --global user.email "${{ secrets.BOT_GITHUB_USERNAME}}@no-reply.users.github.com"
-            git config --global user.name "${{ secrets.BOT_GITHUB_USERNAME}}"
-
             echo "Removing release from: Activiti/activiti-cloud-full-chart"
             gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-full-chart"
-            gh repo clone Activiti/activiti-cloud-full-chart && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
-
-            echo "Removing release from: Activiti/activiti-scripts"
-            gh release delete -R Activiti/activiti-scripts -y ${VERSION} || true
-            echo "Removing tag from: Activiti/activiti-scripts"
-            gh repo clone Activiti/activiti-scripts && cd "$(basename "$_" .git)"
-            git push origin --delete ${VERSION} || true
-
-            echo "Removing release from: Activiti/activiti-cloud"
-            gh release delete -R Activiti/activiti-cloud -y ${VERSION} || true
-            echo "Removing tag from: Activiti/activiti-cloud"
-            gh repo clone Activiti/activiti-cloud && cd "$(basename "$_" .git)"
-            git push origin --delete ${VERSION} || true
-
-            echo "Removing release from: Activiti/activiti-cloud-common-chart"
-            gh release delete -R Activiti/activiti-cloud-common-chart -y ${VERSION} || true
-            echo "Removing tag from: Activiti/activiti-cloud-common-chart"
-            gh repo clone Activiti/activiti-cloud-common-chart && cd "$(basename "$_" .git)"
-            git push origin --delete ${VERSION} || true
-
-            echo "Removing release from: Activiti/activiti"
-            gh release delete -R Activiti/Activiti -y ${VERSION} || true
-            echo "Removing tag from: Activiti/activiti"
-            gh repo clone Activiti/activiti && cd "$(basename "$_" .git)"
-            git push origin --delete ${VERSION} || true
-
           else
             echo "version does not end with '-mock'."
             echo "Error: The provided version does not end with '-mock.'"

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -15,4 +15,3 @@ jobs:
         with:
           version: ${{ inputs.version }}
           repo: Activiti/activiti-cloud-full-chart
-

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -23,31 +23,31 @@ jobs:
             echo "Removing release from: Activiti/activiti-cloud-full-chart"
             gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-full-chart"
-            gh repo clone Activiti/activiti-cloud-full-chart --depth 1
+            gh repo clone Activiti/activiti-cloud-full-chart
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-scripts"
             gh release delete -R Activiti/activiti-scripts -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-scripts"
-            gh repo clone Activiti/activiti-scripts --depth 1
+            gh repo clone Activiti/activiti-scripts
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-cloud"
             gh release delete -R Activiti/activiti-cloud -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud"
-            gh repo clone Activiti/activiti-cloud --depth 1
+            gh repo clone Activiti/activiti-cloud
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-cloud-common-chart"
             gh release delete -R Activiti/activiti-cloud-common-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-common-chart"
-            gh repo clone Activiti/activiti-cloud-common-chart --depth 1
+            gh repo clone Activiti/activiti-cloud-common-chart
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti"
             gh release delete -R Activiti/Activiti -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti"
-            gh repo clone Activiti/activiti --depth 1
+            gh repo clone Activiti/activiti
             git push origin --delete ${VERSION} || true
 
           else

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
-            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
+            #gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
             echo "Activiti/activiti-cloud-full-chart cleaned"
             gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION}
             echo "Activiti/activiti-scripts cleaned"

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -23,31 +23,31 @@ jobs:
             echo "Removing release from: Activiti/activiti-cloud-full-chart"
             gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-full-chart"
-            gh repo clone Activiti/activiti-cloud-full-chart
+            gh repo clone Activiti/activiti-cloud-full-chart && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-scripts"
             gh release delete -R Activiti/activiti-scripts -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-scripts"
-            gh repo clone Activiti/activiti-scripts
+            gh repo clone Activiti/activiti-scripts && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-cloud"
             gh release delete -R Activiti/activiti-cloud -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud"
-            gh repo clone Activiti/activiti-cloud
+            gh repo clone Activiti/activiti-cloud && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti-cloud-common-chart"
             gh release delete -R Activiti/activiti-cloud-common-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-common-chart"
-            gh repo clone Activiti/activiti-cloud-common-chart
+            gh repo clone Activiti/activiti-cloud-common-chart && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
 
             echo "Removing release from: Activiti/activiti"
             gh release delete -R Activiti/Activiti -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti"
-            gh repo clone Activiti/activiti
+            gh repo clone Activiti/activiti && cd "$(basename "$_" .git)"
             git push origin --delete ${VERSION} || true
 
           else

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           version: ${{ inputs.version }}
           repo: Activiti/activiti-cloud-full-chart
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,6 +20,9 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
+            git config --global user.email "${{ secrets.BOT_GITHUB_USERNAME}}@no-reply.users.github.com"
+            git config --global user.name "${{ secrets.BOT_GITHUB_USERNAME}}"
+
             echo "Removing release from: Activiti/activiti-cloud-full-chart"
             gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
             echo "Removing tag from: Activiti/activiti-cloud-full-chart"

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,16 +20,20 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
-            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
-            echo "Activiti/activiti-cloud-full-chart cleaned"
-            gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION}
-            echo "Activiti/activiti-scripts cleaned"
-            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}
-            echo "Activiti/activiti-cloud cleaned"
-            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}
-            echo "Activiti/activiti-cloud-common-chart cleaned"
-            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}
-            echo "Activiti/activiti cleaned"
+            echo "Removing releases and tags from: Activiti/activiti-cloud-full-chart"
+            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION} || true
+
+            echo "Removing releases and tags from: Activiti/activiti-scripts"
+            gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION} || true
+
+            echo "Removing releases and tags from: Activiti/activiti-cloud"
+            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} || true
+
+            echo "Removing releases and tags from: Activiti/activiti-cloud-common-chart"
+            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} || true
+
+            echo "Removing releases and tags from: Activiti/activiti"
+            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} || true
 
           else
             echo "version does not end with '-mock'."

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -21,10 +21,15 @@ jobs:
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
             gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
+            echo "Activiti/activiti-cloud-full-chart cleaned"
             gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION}
+            echo "Activiti/activiti-scripts cleaned"
             gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}
+            echo "Activiti/activiti-cloud cleaned"
             gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}
+            echo "Activiti/activiti-cloud-common-chart cleaned"
             gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}
+            echo "Activiti/activiti cleaned"
 
           else
             echo "version does not end with '-mock'."

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           version: ${{ inputs.version }}
           repo: Activiti/activiti-cloud-full-chart
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -11,31 +11,8 @@ jobs:
   delete_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./.github/actions/remove-mock-release-and-tag
         with:
-          repository: Activiti/activiti-cloud-full-chart
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          version: ${{ inputs.version }}
+          repo: Activiti/activiti-cloud-full-chart
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v3.6.0
-        id: check-tag
-        with:
-          tag: ${{ inputs.version }}
-
-
-      - name: Delete release if the provided version ends with "-mock"
-        id: delete_version
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          if [[ "${VERSION}" == *-mock ]]; then
-            echo "Removing release from: Activiti/activiti-cloud-full-chart"
-            gh release delete -R Activiti/activiti-cloud-full-chart -y ${VERSION} || true
-            echo "Removing tag from: Activiti/activiti-cloud-full-chart"
-            git push origin --delete ${VERSION} || true
-          else
-            echo "version does not end with '-mock'."
-            echo "Error: The provided version does not end with '-mock.'"
-            exit 1
-          fi

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -10,11 +10,18 @@ on:
 jobs:
   delete_version:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository: [ 'Activiti/activiti-cloud-full-chart',
+                      'Activiti/activiti-scripts',
+                      'Activiti/activiti-cloud',
+                      'Activiti/activiti-cloud-common-chart',
+                      'Activiti/activiti' ]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/remove-mock-release-and-tag
         with:
           version: ${{ inputs.version }}
-          repo: Activiti/activiti-cloud-full-chart
+          repo: ${{ matrix.repository }}
           gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
       - uses: actions/checkout@v3

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -11,6 +11,7 @@ jobs:
   delete_version:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         repository: [ 'Activiti/activiti-cloud-full-chart',
                       'Activiti/activiti-scripts',

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -11,6 +11,7 @@ jobs:
   delete_version:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/remove-mock-release-and-tag
         with:
           version: ${{ inputs.version }}

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -18,10 +18,10 @@ jobs:
                       'Activiti/activiti-cloud-common-chart',
                       'Activiti/activiti' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - uses: ./.github/actions/remove-mock-release-and-tag
         with:
           version: ${{ inputs.version }}
           repo: ${{ matrix.repository }}
           gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -409,6 +409,7 @@ jobs:
           - activiti-cloud
           - activiti-cloud-common-chart
           - activiti-cloud-full-chart
+          - activiti-scripts
     env:
       VERSION: ${{ needs.load-release-info.outputs.version }}
       NOTES_START_TAG: ${{ needs.load-release-info.outputs.notes-start-tag }}


### PR DESCRIPTION
This change gives an option to remove tags and releases separately which is crucial because there is no API to remove git tags and API for release removal will not remove a tag when release does not exist