### PR TITLE
AAE-37802 Enhance mock release cleanup

### DIFF
--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -20,11 +20,29 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ "${VERSION}" == *-mock ]]; then
+            echo "Starting cleanup for version: ${VERSION}"
+            
+            echo "Deleting release from Activiti/activiti-cloud-full-chart..."
             gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
-            gh release delete -R Activiti/activiti-scripts -y --cleanup-tag ${VERSION}
+            echo "✓ Deleted release from Activiti/activiti-cloud-full-chart"
+            
+            echo "Deleting release from Activiti/activiti-cloud..."
             gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}
+            echo "✓ Deleted release from Activiti/activiti-cloud"
+            
+            echo "Deleting release from Activiti/activiti-cloud-common-chart..."
             gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}
+            echo "✓ Deleted release from Activiti/activiti-cloud-common-chart"
+            
+            echo "Deleting release from Activiti/Activiti..."
             gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}
+            echo "✓ Deleted release from Activiti/Activiti"
+            
+            echo "Deleting tag from Activiti/activiti-scripts..."
+            gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION}
+            echo "✓ Deleted tag from Activiti/activiti-scripts"
+            
+            echo "✅ Cleanup completed for version: ${VERSION}"
 
           else
             echo "version does not end with '-mock'."

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -10,70 +10,41 @@ on:
 jobs:
   delete_version:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - { name: "Activiti/activiti-cloud-full-chart", type: "release" }
+          - { name: "Activiti/activiti-cloud", type: "release" }
+          - { name: "Activiti/activiti-cloud-common-chart", type: "release" }
+          - { name: "Activiti/Activiti", type: "release" }
+          - { name: "Activiti/activiti-scripts", type: "tag" }
+      fail-fast: false
     steps:
       - name: Delete version if the provided version ends with "-mock"
-        id: delete_version
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          REPO: ${{ inputs.repository }}
           VERSION: ${{ inputs.version }}
         run: |
-          if [[ "${VERSION}" == *-mock ]]; then
-            echo "Starting cleanup for version: ${VERSION}"
-            
-            # Initialize error tracking
-            has_errors=false
-            
-            echo "Deleting release from Activiti/activiti-cloud-full-chart..."
-            if gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}; then
-              echo "✓ Deleted release from Activiti/activiti-cloud-full-chart"
-            else
-              echo "❌ Failed to delete release from Activiti/activiti-cloud-full-chart"
-              has_errors=true
-            fi
-            
-            echo "Deleting release from Activiti/activiti-cloud..."
-            if gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}; then
-              echo "✓ Deleted release from Activiti/activiti-cloud"
-            else
-              echo "❌ Failed to delete release from Activiti/activiti-cloud"
-              has_errors=true
-            fi
-            
-            echo "Deleting release from Activiti/activiti-cloud-common-chart..."
-            if gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}; then
-              echo "✓ Deleted release from Activiti/activiti-cloud-common-chart"
-            else
-              echo "❌ Failed to delete release from Activiti/activiti-cloud-common-chart"
-              has_errors=true
-            fi
-            
-            echo "Deleting release from Activiti/Activiti..."
-            if gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}; then
-              echo "✓ Deleted release from Activiti/Activiti"
-            else
-              echo "❌ Failed to delete release from Activiti/Activiti"
-              has_errors=true
-            fi
-            
-            echo "Deleting tag from Activiti/activiti-scripts..."
-            if gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION}; then
-              echo "✓ Deleted tag from Activiti/activiti-scripts"
-            else
-              echo "❌ Failed to delete tag from Activiti/activiti-scripts"
-              has_errors=true
-            fi
-            
-            if [[ "$has_errors" == "true" ]]; then
-              echo "❌ Cleanup completed with errors for version: ${VERSION}"
-              exit 1
-            else
-              echo "✅ Cleanup completed successfully for version: ${VERSION}"
-            fi
-
-          else
-            echo "version does not end with '-mock'."
+          if [[ "${VERSION}" != *-mock ]]; then
             echo "Error: The provided version does not end with '-mock.'"
             exit 1
+          fi
+          
+          echo "Starting cleanup for version: ${VERSION} from ${{ matrix.repo.name }}"
+          
+          if [[ "${{ matrix.repo.type }}" == "release" ]]; then
+            if gh release delete -R ${{ matrix.repo.name }} -y --cleanup-tag ${VERSION}; then
+              echo "✓ Deleted release from ${{ matrix.repo.name }}"
+            else
+              echo "❌ Failed to delete release from ${{ matrix.repo.name }}"
+              exit 1
+            fi
+          else
+            if gh api --silent -X DELETE /repos/${{ matrix.repo.name }}/git/refs/tags/${VERSION}; then
+              echo "✓ Deleted tag from ${{ matrix.repo.name }}"
+            else
+              echo "❌ Failed to delete tag from ${{ matrix.repo.name }}"
+              exit 1
+            fi
           fi

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -22,27 +22,45 @@ jobs:
           if [[ "${VERSION}" == *-mock ]]; then
             echo "Starting cleanup for version: ${VERSION}"
             
+            # Initialize error tracking
+            has_errors=false
+            
             echo "Deleting release from Activiti/activiti-cloud-full-chart..."
-            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}
-            echo "✓ Deleted release from Activiti/activiti-cloud-full-chart"
+            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud-full-chart"; has_errors=true; }
+            if [[ "$has_errors" == "false" ]]; then
+              echo "✓ Deleted release from Activiti/activiti-cloud-full-chart"
+            fi
             
             echo "Deleting release from Activiti/activiti-cloud..."
-            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}
-            echo "✓ Deleted release from Activiti/activiti-cloud"
+            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud"; has_errors=true; }
+            if [[ "$has_errors" == "false" ]] || [[ "$(gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} 2>&1)" != *"failed"* ]]; then
+              echo "✓ Deleted release from Activiti/activiti-cloud"
+            fi
             
             echo "Deleting release from Activiti/activiti-cloud-common-chart..."
-            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}
-            echo "✓ Deleted release from Activiti/activiti-cloud-common-chart"
+            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud-common-chart"; has_errors=true; }
+            if [[ "$(gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} 2>&1; echo $?)" == "0" ]]; then
+              echo "✓ Deleted release from Activiti/activiti-cloud-common-chart"
+            fi
             
             echo "Deleting release from Activiti/Activiti..."
-            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}
-            echo "✓ Deleted release from Activiti/Activiti"
+            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/Activiti"; has_errors=true; }
+            if [[ "$(gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} 2>&1; echo $?)" == "0" ]]; then
+              echo "✓ Deleted release from Activiti/Activiti"
+            fi
             
             echo "Deleting tag from Activiti/activiti-scripts..."
-            gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION}
-            echo "✓ Deleted tag from Activiti/activiti-scripts"
+            gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION} || { echo "❌ Failed to delete tag from Activiti/activiti-scripts"; has_errors=true; }
+            if [[ "$(gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION} 2>&1; echo $?)" == "0" ]]; then
+              echo "✓ Deleted tag from Activiti/activiti-scripts"
+            fi
             
-            echo "✅ Cleanup completed for version: ${VERSION}"
+            if [[ "$has_errors" == "true" ]]; then
+              echo "❌ Cleanup completed with errors for version: ${VERSION}"
+              exit 1
+            else
+              echo "✅ Cleanup completed successfully for version: ${VERSION}"
+            fi
 
           else
             echo "version does not end with '-mock'."

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -26,33 +26,43 @@ jobs:
             has_errors=false
             
             echo "Deleting release from Activiti/activiti-cloud-full-chart..."
-            gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud-full-chart"; has_errors=true; }
-            if [[ "$has_errors" == "false" ]]; then
+            if gh release delete -R Activiti/activiti-cloud-full-chart -y --cleanup-tag ${VERSION}; then
               echo "✓ Deleted release from Activiti/activiti-cloud-full-chart"
+            else
+              echo "❌ Failed to delete release from Activiti/activiti-cloud-full-chart"
+              has_errors=true
             fi
             
             echo "Deleting release from Activiti/activiti-cloud..."
-            gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud"; has_errors=true; }
-            if [[ "$has_errors" == "false" ]] || [[ "$(gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION} 2>&1)" != *"failed"* ]]; then
+            if gh release delete -R Activiti/activiti-cloud -y --cleanup-tag ${VERSION}; then
               echo "✓ Deleted release from Activiti/activiti-cloud"
+            else
+              echo "❌ Failed to delete release from Activiti/activiti-cloud"
+              has_errors=true
             fi
             
             echo "Deleting release from Activiti/activiti-cloud-common-chart..."
-            gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/activiti-cloud-common-chart"; has_errors=true; }
-            if [[ "$(gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION} 2>&1; echo $?)" == "0" ]]; then
+            if gh release delete -R Activiti/activiti-cloud-common-chart -y --cleanup-tag ${VERSION}; then
               echo "✓ Deleted release from Activiti/activiti-cloud-common-chart"
+            else
+              echo "❌ Failed to delete release from Activiti/activiti-cloud-common-chart"
+              has_errors=true
             fi
             
             echo "Deleting release from Activiti/Activiti..."
-            gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} || { echo "❌ Failed to delete release from Activiti/Activiti"; has_errors=true; }
-            if [[ "$(gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION} 2>&1; echo $?)" == "0" ]]; then
+            if gh release delete -R Activiti/Activiti -y --cleanup-tag ${VERSION}; then
               echo "✓ Deleted release from Activiti/Activiti"
+            else
+              echo "❌ Failed to delete release from Activiti/Activiti"
+              has_errors=true
             fi
             
             echo "Deleting tag from Activiti/activiti-scripts..."
-            gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION} || { echo "❌ Failed to delete tag from Activiti/activiti-scripts"; has_errors=true; }
-            if [[ "$(gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION} 2>&1; echo $?)" == "0" ]]; then
+            if gh api --silent -X DELETE /repos/Activiti/activiti-scripts/git/refs/tags/${VERSION}; then
               echo "✓ Deleted tag from Activiti/activiti-scripts"
+            else
+              echo "❌ Failed to delete tag from Activiti/activiti-scripts"
+              has_errors=true
             fi
             
             if [[ "$has_errors" == "true" ]]; then

--- a/.github/workflows/mock-release-cleanup.yml
+++ b/.github/workflows/mock-release-cleanup.yml
@@ -30,9 +30,9 @@ jobs:
             echo "Error: The provided version does not end with '-mock.'"
             exit 1
           fi
-          
+
           echo "Starting cleanup for version: ${VERSION} from ${{ matrix.repo.name }}"
-          
+
           if [[ "${{ matrix.repo.type }}" == "release" ]]; then
             if gh release delete -R ${{ matrix.repo.name }} -y --cleanup-tag ${VERSION}; then
               echo "✓ Deleted release from ${{ matrix.repo.name }}"


### PR DESCRIPTION
This pull request refactors the `mock-release-cleanup.yml` GitHub Actions workflow to make the release/tag cleanup process more robust and maintainable. The main changes include introducing a matrix strategy for repository cleanup, improving error handling, and ensuring only mock versions are processed.

**Workflow improvements:**

* Added a matrix strategy under the `delete_version` job to iterate over a list of repositories, specifying whether each should be cleaned up as a release or a tag. This removes hardcoded repository names and centralizes configuration.
* Updated the cleanup logic to only proceed if the provided version ends with `-mock`, and to fail with a clear error message otherwise, improving safety and clarity.
* For each repository, the workflow now conditionally deletes either a release or a tag based on the repository type, with success/failure logging for each operation.